### PR TITLE
add tmp file to handle git complaining about overwriting files

### DIFF
--- a/.github/workflows/write-json.yml
+++ b/.github/workflows/write-json.yml
@@ -34,7 +34,9 @@ jobs:
           git fetch origin compiled-develop  --recurse-submodules=no
           git config --global user.name 'GitHub Action'
           git config --global user.email 'action@github.com'
+          mv src/config_stp/configs/config_stp.json config_stp.json.tmp
           git checkout compiled-develop
+          mv config_stp.json.tmp src/config_stp/configs/config_stp.json
           git add src/config_stp/configs/config_stp.json
           git commit -m "update JSON config parsed from TOML changes"
           git push


### PR DESCRIPTION
want to avoid doing any force maneuvers. Because the .json file already exists on the compiled branch, git will not allow switching branches due to the new branch overwriting in-progress changes. So, now just making a tmp file, checking out the branch, then overwriting the file